### PR TITLE
Remove lint step from CI

### DIFF
--- a/.github/workflows/fastapi-sample.yaml
+++ b/.github/workflows/fastapi-sample.yaml
@@ -34,7 +34,3 @@ jobs:
       - name: Run test
         run: make test
         working-directory: ${{ env.WORKING_DIRECTORY }}
-
-      - name: Run lint
-        run: make lint
-        working-directory: ${{ env.WORKING_DIRECTORY }}


### PR DESCRIPTION
Removed the lint rule from GitHub Action because it contains rules which don't match for coding tests.